### PR TITLE
Fix standard MAC address format not working on linux, expand readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,20 +16,51 @@ Virtual reality basestation power management in Rust
 Usage: lighthouse [OPTIONS] --state <STATE>
 
 Options:
-  -s, --state <STATE>     V1: [OFF|ON] [BSID] | V2: [OFF|ON|STANDBY] (BSID)
-  -b, --bsid <BSID>       Basestation BSID
-  -v, --verbose...        More output per occurrence
-  -q, --quiet...          Less output per occurrence
-  -h, --help              Print help information
-  -t, --timeout <SECONDS> Scan timeout
+  -s, --state <STATE>      V1: [OFF|ON] | V2: [OFF|ON|STANDBY]
+  -b, --bsid <BSID>        V1: Basestation BSID (Required) | V2: Bluetooth Device Identifier (Optional)
+  -v, --verbose...         Increase logging verbosity
+  -q, --quiet...           Decrease logging verbosity
+  -t, --timeout <TIMEOUT>  Request timeout in seconds [default: 10]
+  -h, --help               Print help
 ```
 V1 Basestations require an 8 character BSID found on the device to work.
 
 V2 Basestations do not require BSID. But you can specify their MAC address as BSID to manage a specific device.
 
-## Example
-V1: `$ lighthouse -s on -b aabbccdd`  
-V2: `$ lighthouse -s on` or `$ lighthouse -s on -b A1:B2:C3:D4:E5:F6`  
+### Examples
+
+**Turning a V1 lighthouse on:**
+
+Find the BSID at the back of the device.
+
+```bash
+$ lighthouse --state on --bsid aabbccdd
+```  
+**Turning on any V2 lighthouses within range:**
+
+```bash
+$ lighthouse --state on
+```
+
+**Turning on a specific V2 lighthouse:**
+
+Run once with verbose parameters to find the MAC address for each lighthouse:
+```bash
+$ lighthouse -vv --state off
+``` 
+
+This will show the device path or MAC address within square brackets, looking something like this:
+```
+2025-02-28T22:14:58.528048Z  INFO lighthouse: Found 'LHB-6DC32F38' [hci0/dev_E2_5A_B0_E4_97_AD]
+2025-02-28T22:15:33.543205Z  INFO lighthouse: LHB-6DC32F38 [hci0/dev_E2_5A_B0_E4_97_AD]: OFF
+```
+
+Use the ID shown in the square brackets in the previous command as the bsid to manage a specific lighthouse:
+```bash
+$ lighthouse --state on --bsid "hci0/dev_E2_5A_B0_E4_97_AD"
+# or
+$ lighthouse --state on --bsid "E2:5A:B0:E4:97:AD"
+```
 
 ## macOS
 Enable the Bluetooth permission for your terminal. You can do the latter by going to System Preferences → Security & Privacy → Privacy → Bluetooth, clicking the '+' button, and selecting 'Terminal' (or iTerm or whichever terminal application you use).

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,11 @@ async fn main() -> Result<(), Error> {
             {
                 if let Some(bsid) = &args.bsid
                 {
-                    if !peripheral.id().to_string().eq_ignore_ascii_case(bsid) {
+                    // On Linux systems the peripheral ID will be something like "hci0/dev_A1_B2_C3_D4_E5_F6"
+                    // instead of "A1:B2:C3:D4:E5:F6". Normalize the strings to allow user input in either format.
+                    let normalized_peripheral_id = peripheral.id().to_string().to_lowercase().replace("_", ":");
+                    let normalized_input = bsid.to_lowercase().replace("_", ":");
+                    if !normalized_peripheral_id.contains(normalized_input.as_str()) {
                         continue;
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,17 +17,18 @@ const V2_UUID: &str = "00001525-1212-efde-1523-785feabcd124";
 
 #[derive(Debug, Parser)]
 struct Args {
-    /// V1: [OFF|ON] [BSID] | V2: [OFF|ON|STANDBY] (BSID)
+    /// V1: [OFF|ON] | V2: [OFF|ON|STANDBY]
     #[arg(short, long)]
     state: String,
 
-    /// V1: Basestation BSID
+    /// V1: Basestation BSID (Required) | V2: Bluetooth Device Identifier (Optional)
     #[arg(short, long)]
     bsid: Option<String>,
 
     #[clap(flatten)]
     verbose: Verbosity,
 
+    /// Request timeout in seconds
     #[arg(short, long, default_value_t = 10)]
     timeout: u64
 }


### PR DESCRIPTION
On Linux the peripheral ID will be something like `hci0/dev_E2_5A_B0_E4_97_AD` while I assume on Windows it would just be a normal MAC address format like `E2:5A:B0:E4:97:AD`.

This PR makes it possible to use either format in the `--bsid` parameter on Linux. It also expands a bit on the instructions for how to find the peripheral ID.

My apologies if the code changes look weird in some way, this is literally the first time I've touched Rust code so I'm mostly guessing what the best way of doing things would be.